### PR TITLE
Turn site into single scrolling page

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,6 +1,8 @@
 <nav class="site-nav">
   <div class="nav-links">
-    <a href="{{ '/' | relative_url }}" class="nav-link">Home</a>
-    <a href="{{ '/posts' | relative_url }}" class="nav-link">Blog Posts</a>
-  </div>
-</nav>
+    <a href="#home" class="nav-link">Home</a>
+    <a href="#about" class="nav-link">About</a>
+    <a href="#resume" class="nav-link">Resume</a>
+    <a href="#blog" class="nav-link">Blog</a>
+    <a href="#contact" class="nav-link">Contact</a>
+  </div></nav>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
     <link rel="stylesheet" href="{{ '/assets/css/navigation.css' | relative_url }}">
     <link rel="stylesheet" href="{{ '/assets/css/blog.css' | relative_url }}">
+    <link rel="stylesheet" href="{{ '/assets/css/onepage.css' | relative_url }}">
     <script src="{{ '/assets/js/scale.fix.js' | relative_url }}"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
 

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -1,33 +1,55 @@
 ---
-# Feel free to add content and custom Front Matter to this file.
-# To modify the layout, see https://jekyllrb.com/docs/themes/#overriding-theme-defaults
-
-layout: default #home 
+layout: default
 title: "Harry Atwal"
 permalink: /
 ---
 
+<section id="home">
 
 # Harry Atwal
 
-Welcome to my personal website! I am a passionate machine learning researcher with a keen interest in developing innovative solutions to complex problems. Here, you can find information about my projects, my resume, and my contact details. 
+Welcome to my personal website! I am a passionate machine learning researcher with a keen interest in developing innovative solutions to complex problems. Here, you can find information about my projects, my resume, and my contact details.
 
-This site will also serve as a platform for me to share my thoughts on various topics related to machine learning and artificial intelligence. Sometimes I will write about things that having nothing to do with machine learning or AI. I'm a father, husband, and human being after. I enjoy mountain biking, consider myself a tinker (both electronics and woodworking), and love to cook.
+This site will also serve as a platform for me to share my thoughts on various topics related to machine learning and artificial intelligence. Sometimes I will write about things that have nothing to do with machine learning or AI. I'm a father, husband, and human being after. I enjoy mountain biking, consider myself a tinker (both electronics and woodworking), and love to cook.
+
+</section>
+
+<section id="about">
 
 ## About Me
 
-I am a machine learning researcher with experience in various domains including natural language processing, computer vision, and reinforcement learning. My goal is to leverage machine learning techniques to create impactful and scalable solutions. 
+I am a machine learning researcher with experience in various domains including natural language processing, computer vision, and reinforcement learning. My goal is to leverage machine learning techniques to create impactful and scalable solutions.
 
-The last 7 years i've worked in machine vision projects that incoroporate machine learning. I've worked on projects that range from simple object detection to complex image segmentation. I've also worked on projects that involve reinforcement learning and natural language processing. As a researcher at the University of North Carolina Wilmington; I was able to work on various projects that involved machine learning and computer vision. 
+The last 7 years I've worked in machine vision projects that incorporate machine learning. I've worked on projects that range from simple object detection to complex image segmentation. I've also worked on projects that involve reinforcement learning and natural language processing. As a researcher at the University of North Carolina Wilmington, I was able to work on various projects that involved machine learning and computer vision.
 
-## [blog](/blog)
+</section>
+
+<section id="blog">
+
+## Blog
+
+Here are some of my latest posts:
+
+{% for post in site.posts limit:5 %}
+- [{{ post.title }}]({{ post.url | relative_url }}) <small>{{ post.date | date: "%B %d, %Y" }}</small>
+{% endfor %}
+
+</section>
+
+<section id="resume">
 
 ## Resume
 
 You can view my resume [here](/content/AtwalH-Modern2024.pdf).
+
+</section>
+
+<section id="contact">
 
 ## Contact
 
 Feel free to reach out to me at [harry@harryatwal.com](mailto:harry@harryatwal.com) or connect with me on [LinkedIn](https://www.linkedin.com/in/harry-atwal-6951696b/).
 
 Thank you for visiting my website!
+
+</section>

--- a/assets/css/onepage.css
+++ b/assets/css/onepage.css
@@ -1,0 +1,13 @@
+html {
+  scroll-behavior: smooth;
+}
+
+section {
+  padding: 2rem 0;
+}
+
+.site-nav {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+}


### PR DESCRIPTION
## Summary
- create a single-page layout in `index.md` with multiple sections
- add anchors in the navigation for smooth scrolling
- include new `onepage.css` for sticky nav and smooth scrolling
- link new stylesheet in the default layout

## Testing
- `bundle exec jekyll build` *(fails: bundler not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eba408474832d8f3165a13078c4a2